### PR TITLE
Change the az_ulib_ipc_publish API to optionally return the interface…

### DIFF
--- a/inc/az_ulib_ipc_api.h
+++ b/inc/az_ulib_ipc_api.h
@@ -51,7 +51,7 @@ typedef _az_ulib_ipc_interface_handle az_ulib_ipc_interface_handle;
  * execution.
  *
  * @note    This API **is not** thread safe, the other IPC API shall only be called after the
- * initialization process is completely done.
+ *          initialization process is completely done.
  *
  * @param[in]   ipc_handle      The #az_ulib_ipc* that points to a memory position where
  *                              the IPC shall create its control block. It cannot be `NULL`.
@@ -104,10 +104,23 @@ static inline AZ_ULIB_RESULT az_ulib_ipc_deinit(void) {
 /**
  * @brief   Publish a new interface on the IPC.
  *
+ * This API publishes a new interface in the IPC using the interface descriptor. The interface
+ * descriptor shall be valid up to the interface is unpublished with success.
+ *
+ * Optionally, this API may return the handle of the interface in the IPC. This handle will be
+ * automatically release when the interface is unpublished.
+ *
+ * @note    **Try to release the handle returned by this API may result in
+ *          #AZ_ULIB_NO_SUCH_ELEMENT_ERROR or a future segmentation fault.**
+ *
  * @param[in]   interface_descriptor  The `const` #az_ulib_interface_descriptor* with the
  *                                    descriptor of the interface. It cannot be `NULL` and
  *                                    shall be valid up to the interface is unpublished with
  *                                    success.
+ * @param[out]  interface_handle      A pointer to #az_ulib_ipc_interface_handle to return the
+ *                                    handle of the published interface in the IPC. It may be
+ *                                    `NULL`. If it is `NULL`, this API will not return the
+ *                                    interface handle.
  *
  * @return The #AZ_ULIB_RESULT with the result of the interface publish.
  *  @retval #AZ_ULIB_SUCCESS                  If the interface is published with success.
@@ -116,11 +129,14 @@ static inline AZ_ULIB_RESULT az_ulib_ipc_deinit(void) {
  *                                            interface.
  */
 static inline AZ_ULIB_RESULT az_ulib_ipc_publish(
-    const az_ulib_interface_descriptor* interface_descriptor) {
+    const az_ulib_interface_descriptor* interface_descriptor,
+    az_ulib_ipc_interface_handle* interface_handle) {
 #ifdef AZ_ULIB_CONFIG_IPC_VALIDATE_CONTRACT
-  return _az_ulib_ipc_publish(interface_descriptor);
+  return _az_ulib_ipc_publish(
+      interface_descriptor, (_az_ulib_ipc_interface_handle*)interface_handle);
 #else
-  return _az_ulib_ipc_publish_no_contract(interface_descriptor);
+  return _az_ulib_ipc_publish_no_contract(
+      interface_descriptor, (_az_ulib_ipc_interface_handle*)interface_handle);
 #endif /* AZ_ULIB_CONFIG_IPC_VALIDATE_CONTRACT */
 }
 

--- a/inc/az_ulib_ipc_api.h
+++ b/inc/az_ulib_ipc_api.h
@@ -105,10 +105,10 @@ static inline AZ_ULIB_RESULT az_ulib_ipc_deinit(void) {
  * @brief   Publish a new interface on the IPC.
  *
  * This API publishes a new interface in the IPC using the interface descriptor. The interface
- * descriptor shall be valid up to the interface is unpublished with success.
+ * descriptor shall be valid up to the point when the interface is unpublished with success.
  *
  * Optionally, this API may return the handle of the interface in the IPC. This handle will be
- * automatically release when the interface is unpublished.
+ * automatically released when the interface is unpublished.
  *
  * @note    **Try to release the handle returned by this API may result in
  *          #AZ_ULIB_NO_SUCH_ELEMENT_ERROR or a future segmentation fault.**

--- a/inc/internal/az_ulib_ipc.h
+++ b/inc/internal/az_ulib_ipc.h
@@ -51,13 +51,17 @@ MOCKABLE_FUNCTION(
     AZ_ULIB_RESULT,
     _az_ulib_ipc_publish_no_contract,
     const az_ulib_interface_descriptor*,
-    interface_descriptor);
+    interface_descriptor,
+    _az_ulib_ipc_interface_handle*,
+    interface_handle);
 MOCKABLE_FUNCTION(
     ,
     AZ_ULIB_RESULT,
     _az_ulib_ipc_publish,
     const az_ulib_interface_descriptor*,
-    interface_descriptor);
+    interface_descriptor,
+    _az_ulib_ipc_interface_handle*,
+    interface_handle);
 
 #ifdef AZ_ULIB_CONFIG_IPC_UNPUBLISH
 MOCKABLE_FUNCTION(

--- a/samples/ipc_call_interface/src/math.c
+++ b/samples/ipc_call_interface/src/math.c
@@ -51,7 +51,7 @@ AZ_ULIB_DESCRIPTOR_CREATE(
     AZ_ULIB_DESCRIPTOR_ADD_METHOD(MATH_INTERFACE_SUM_METHOD_NAME, sum_concrete),
     AZ_ULIB_DESCRIPTOR_ADD_METHOD(MATH_INTERFACE_SUBTRACTION_METHOD_NAME, subtraction_concrete));
 
-AZ_ULIB_RESULT math_publish_interface(void) { return az_ulib_ipc_publish(&MATH_DESCRIPTOR); }
+AZ_ULIB_RESULT math_publish_interface(void) { return az_ulib_ipc_publish(&MATH_DESCRIPTOR, NULL); }
 
 AZ_ULIB_RESULT math_unpublish_interface(void) {
 #ifdef AZ_ULIB_CONFIG_IPC_UNPUBLISH

--- a/src/az_ulib_ipc/az_ulib_ipc.c
+++ b/src/az_ulib_ipc/az_ulib_ipc.c
@@ -130,7 +130,8 @@ AZ_ULIB_RESULT _az_ulib_ipc_deinit(void) {
 }
 
 AZ_ULIB_RESULT _az_ulib_ipc_publish_no_contract(
-    const az_ulib_interface_descriptor* interface_descriptor) {
+    const az_ulib_interface_descriptor* interface_descriptor,
+    _az_ulib_ipc_interface_handle* interface_handle) {
   AZ_ULIB_RESULT result;
   _az_ulib_ipc_interface* new_interface;
 
@@ -153,6 +154,10 @@ AZ_ULIB_RESULT _az_ulib_ipc_publish_no_contract(
       new_interface->running_count = 0;
       new_interface->running_count_low_watermark = 0;
 #endif // AZ_ULIB_CONFIG_IPC_UNPUBLISH
+      if (interface_handle != NULL) {
+        /*az_ulib_ipc_publish_return_handle_succeed*/
+        *interface_handle = new_interface;
+      }
       result = AZ_ULIB_SUCCESS;
     }
   }
@@ -162,13 +167,15 @@ AZ_ULIB_RESULT _az_ulib_ipc_publish_no_contract(
 }
 
 AZ_ULIB_RESULT
-_az_ulib_ipc_publish(const az_ulib_interface_descriptor* interface_descriptor) {
+_az_ulib_ipc_publish(
+    const az_ulib_interface_descriptor* interface_descriptor,
+    _az_ulib_ipc_interface_handle* interface_handle) {
   AZ_UCONTRACT(
       /*az_ulib_ipc_publish_with_non_initialized_ipc_failed*/
       AZ_UCONTRACT_REQUIRE_NOT_NULL(ipc, AZ_ULIB_NOT_INITIALIZED_ERROR),
       /*az_ulib_ipc_publish_with_null_descriptor_failed*/
       AZ_UCONTRACT_REQUIRE_NOT_NULL(interface_descriptor, AZ_ULIB_ILLEGAL_ARGUMENT_ERROR));
-  return _az_ulib_ipc_publish_no_contract(interface_descriptor);
+  return _az_ulib_ipc_publish_no_contract(interface_descriptor, interface_handle);
 }
 
 #ifdef AZ_ULIB_CONFIG_IPC_UNPUBLISH

--- a/tests/tests_e2e/az_ulib_ipc_e2e/az_ulib_ipc_e2e.c
+++ b/tests/tests_e2e/az_ulib_ipc_e2e/az_ulib_ipc_e2e.c
@@ -185,10 +185,10 @@ void init_ipc_and_publish_interfaces(bool shall_initialize) {
   if (shall_initialize) {
     ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_init(&g_ipc));
   }
-  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_publish(&MY_INTERFACE_1_V123));
-  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_publish(&MY_INTERFACE_1_V2));
-  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_publish(&MY_INTERFACE_2_V123));
-  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_publish(&MY_INTERFACE_3_V123));
+  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_publish(&MY_INTERFACE_1_V123, NULL));
+  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_publish(&MY_INTERFACE_1_V2, NULL));
+  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_publish(&MY_INTERFACE_2_V123, NULL));
+  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_publish(&MY_INTERFACE_3_V123, NULL));
 }
 
 void unpublish_interfaces_and_deinit_ipc(void) {

--- a/tests/tests_e2e/az_ulib_ipc_e2e/az_ulib_ipc_e2e.c
+++ b/tests/tests_e2e/az_ulib_ipc_e2e/az_ulib_ipc_e2e.c
@@ -631,10 +631,10 @@ TEST_FUNCTION(az_ulib_ipc_e2e_call_sync_method_in_multiple_threads_and_unpublish
     az_pal_os_sleep(100);
     (void)test_thread_create(&thread_handle[count_thread], &call_sync_thread, interface_handle);
   }
-  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_unpublish(&MY_INTERFACE_1_V123, 1000));
-  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_unpublish(&MY_INTERFACE_2_V123, 1000));
-  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_unpublish(&MY_INTERFACE_1_V2, 1000));
-  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_unpublish(&MY_INTERFACE_3_V123, 1000));
+  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_unpublish(&MY_INTERFACE_1_V123, 10000));
+  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_unpublish(&MY_INTERFACE_2_V123, 10000));
+  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_unpublish(&MY_INTERFACE_1_V2, 10000));
+  ASSERT_ARE_EQUAL(int, AZ_ULIB_SUCCESS, az_ulib_ipc_unpublish(&MY_INTERFACE_3_V123, 10000));
   az_ulib_ipc_release_interface(interface_handle);
 
   /// assert


### PR DESCRIPTION
… handle, so now developers may use interfaces without search for it by name.