### PR TITLE
convert az_ulib_flush_callback from void to az_result

### DIFF
--- a/inc/az_ulib_ustream_forward.h
+++ b/inc/az_ulib_ustream_forward.h
@@ -34,7 +34,7 @@ typedef struct az_ulib_ustream_forward_tag az_ulib_ustream_forward;
 /**
  * @brief   Signature of the function to be invoked by the `az_ulib_ustream_forward_flush`
  *          operation when the `const uint8_t* const` to the buffer has been created.
- *
+ * 
  * @param[in]   buffer                  The `const uint8_t* const` buffer to be handled by the
  *                                      implementation of this callback.
  * @param[in]   size                    The number of `uint8_t` bytes in the
@@ -42,8 +42,22 @@ typedef struct az_ulib_ustream_forward_tag az_ulib_ustream_forward;
  * @param[in]   flush_callback_context  The #az_ulib_callback_context contract held between the
  *                                      owner of this callback and the caller of
  *                                      `az_ulib_ustream_forward_flush`.
+ * 
+ * @returns     The #az_result with the result of the flush_callback.
+ *      @retval #AZ_OK                        If the callback operation succeeded.
+ *      @retval #AZ_ERROR_ULIB_BUSY           If the resource being accessed in the callback 
+ *                                            operation is busy.
+ *      @retval #AZ_ERROR_CANCELED            If any one of the callback's dependent external
+ *                                            calls is canceled.
+ *      @retval #AZ_ERROR_NOT_ENOUGH_SPACE    If there is not enough memory to to finish the
+ *                                            callback operation.
+ *      @retval #AZ_ERROR_ULIB_SECURITY       If any one of the callbacks's dependent
+ *                                            external calls returns an error for security reasons.
+ *      @retval #AZ_ERROR_ULIB_SYSTEM         If any one of the callback's dependencies
+ *                                            fails at the system level.
+ *              
  */
-typedef void (*az_ulib_flush_callback)(
+typedef az_result (*az_ulib_flush_callback)(
     const uint8_t* const buffer,
     size_t size,
     az_ulib_callback_context flush_callback_context);
@@ -180,7 +194,7 @@ struct az_ulib_ustream_forward_tag
  *                                            data from source to destination.
  *      @retval #AZ_ERROR_ULIB_SECURITY       If any one of the flush operation's dependent
  *                                            external calls returns an error for security reasons.
- *      @retval #AZ_ERROR_ULIB_SYSTEM         If any one of the flush operation's dependent
+ *      @retval #AZ_ERROR_ULIB_SYSTEM         If any one of the flush operation's dependencies
  *                                            fails at the system level.
  */
 AZ_NODISCARD AZ_INLINE az_result az_ulib_ustream_forward_flush(

--- a/inc/az_ulib_ustream_forward.h
+++ b/inc/az_ulib_ustream_forward.h
@@ -34,7 +34,7 @@ typedef struct az_ulib_ustream_forward_tag az_ulib_ustream_forward;
 /**
  * @brief   Signature of the function to be invoked by the `az_ulib_ustream_forward_flush`
  *          operation when the `const uint8_t* const` to the buffer has been created.
- * 
+ *
  * @param[in]   buffer                  The `const uint8_t* const` buffer to be handled by the
  *                                      implementation of this callback.
  * @param[in]   size                    The number of `uint8_t` bytes in the
@@ -42,10 +42,10 @@ typedef struct az_ulib_ustream_forward_tag az_ulib_ustream_forward;
  * @param[in]   flush_callback_context  The #az_ulib_callback_context contract held between the
  *                                      owner of this callback and the caller of
  *                                      `az_ulib_ustream_forward_flush`.
- * 
+ *
  * @returns     The #az_result with the result of the flush_callback.
  *      @retval #AZ_OK                        If the callback operation succeeded.
- *      @retval #AZ_ERROR_ULIB_BUSY           If the resource being accessed in the callback 
+ *      @retval #AZ_ERROR_ULIB_BUSY           If the resource being accessed in the callback
  *                                            operation is busy.
  *      @retval #AZ_ERROR_CANCELED            If any one of the callback's dependent external
  *                                            calls is canceled.
@@ -55,7 +55,7 @@ typedef struct az_ulib_ustream_forward_tag az_ulib_ustream_forward;
  *                                            external calls returns an error for security reasons.
  *      @retval #AZ_ERROR_ULIB_SYSTEM         If any one of the callback's dependencies
  *                                            fails at the system level.
- *              
+ *
  */
 typedef az_result (*az_ulib_flush_callback)(
     const uint8_t* const buffer,

--- a/samples/ustream_forward_basic/src/main.c
+++ b/samples/ustream_forward_basic/src/main.c
@@ -19,7 +19,7 @@ typedef struct ustream_forward_basic_context
   char buffer[100];
 } consumer_context;
 
-static void flush_callback(
+static az_result flush_callback(
     const uint8_t* const buffer,
     size_t size,
     az_ulib_callback_context flush_callback_context)
@@ -33,6 +33,8 @@ static void flush_callback(
     
     // adjust offset
     flush_context->offset += size;
+
+    return AZ_OK;
 }
 
 static az_result my_consumer(void)

--- a/src/az_ulib_ustream_forward/az_ulib_ustream_forward.c
+++ b/src/az_ulib_ustream_forward/az_ulib_ustream_forward.c
@@ -58,6 +58,8 @@ static az_result concrete_flush(
   _az_PRECONDITION(AZ_ULIB_USTREAM_FORWARD_IS_TYPE_OF(ustream_forward, api));
   _az_PRECONDITION_NOT_NULL(flush_callback);
 
+  az_result result;
+
   // get size of data
   size_t buffer_size = concrete_get_size(ustream_forward);
 
@@ -66,9 +68,9 @@ static az_result concrete_flush(
       + ustream_forward->_internal.inner_current_position;
 
   // invoke callback
-  (*flush_callback)(buffer, buffer_size, flush_callback_context);
+  result = (*flush_callback)(buffer, buffer_size, flush_callback_context);
 
-  return AZ_OK;
+  return result;
 }
 
 static az_result concrete_read(

--- a/src/az_ulib_ustream_forward/az_ulib_ustream_forward.c
+++ b/src/az_ulib_ustream_forward/az_ulib_ustream_forward.c
@@ -12,7 +12,6 @@
 #include "az_ulib_ustream_forward.h"
 #include "azure/core/az_span.h"
 
-
 #include <azure/core/internal/az_precondition_internal.h>
 
 #ifdef __clang__

--- a/tests/inc/az_ulib_ustream_forward_compliance_e2e.h
+++ b/tests/inc/az_ulib_ustream_forward_compliance_e2e.h
@@ -51,7 +51,7 @@ typedef struct ustream_forward_basic_context
   char buffer[100];
 } consumer_context;
 
-static void flush_callback(
+static az_result flush_callback(
     const uint8_t* const buffer,
     size_t size,
     az_ulib_callback_context flush_callback_context)
@@ -66,6 +66,8 @@ static void flush_callback(
 
   // adjust offset
   flush_context->offset += size;
+
+  return AZ_OK;
 }
 /**
  * Start compliance tests.

--- a/tests/inc/az_ulib_ustream_forward_compliance_ut.h
+++ b/tests/inc/az_ulib_ustream_forward_compliance_ut.h
@@ -43,7 +43,7 @@ static size_t flush_callback_size_check = 0;
 static az_ulib_callback_context flush_callback_context_check;
 
 // mock callback function
-static void mock_flush_callback(
+static az_result mock_flush_callback(
     const uint8_t* const buffer,
     size_t size,
     az_ulib_callback_context flush_callback_context)
@@ -51,6 +51,8 @@ static void mock_flush_callback(
   (void)memcpy(flush_callback_buffer_check, buffer, size);
   flush_callback_size_check = size;
   flush_callback_context_check = flush_callback_context;
+
+  return AZ_OK;
 }
 
 /*


### PR DESCRIPTION
convert az_ulib_flush_callback from void to az_result so the flush operation can handle any errors that occur in the callback